### PR TITLE
AutoWireProperties() now ignores static properties

### DIFF
--- a/Source/Grace/DependencyInjection/Impl/FluentExportStrategyConfiguration.cs
+++ b/Source/Grace/DependencyInjection/Impl/FluentExportStrategyConfiguration.cs
@@ -686,7 +686,7 @@ namespace Grace.DependencyInjection.Impl
 		{
 			foreach (PropertyInfo propertyInfo in typeof(T).GetRuntimeProperties())
 			{
-				if (propertyInfo.CanWrite)
+				if (propertyInfo.CanWrite && !propertyInfo.SetMethod.IsStatic)
 				{
 					ImportPropertyInfo newImportPropertyInfo = new ImportPropertyInfo
 																			 {


### PR DESCRIPTION
Classes with static properties can now be created successfully when AutoWireProperties() is used.

E.g.
  public class SomeClass
  {
    public IDependendy Dependency { get; set; }

```
public static int Counter { get; set; }
```

  }
