### PR TITLE
Add parameter information for method injection

### DIFF
--- a/src/Grace/DependencyInjection/Impl/Expressions/MethodInvokeExpressionCreator.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/MethodInvokeExpressionCreator.cs
@@ -121,14 +121,13 @@ namespace Grace.DependencyInjection.Impl.Expressions
             foreach (var parameter in methodInjection.Method.GetParameters())
             {
                 object key = null;
-                bool isOptinal = false;
 
                 if (request.RequestingScope.ScopeConfiguration.Behaviors.KeyedTypeSelector(parameter.ParameterType))
                 {
                     key = parameter.Name;
                 }
 
-                var found = parameter.ParameterType.IsGenericParameter || isOptinal ||
+                var found = parameter.ParameterType.IsGenericParameter ||
                             request.RequestingScope.CanLocate(parameter.ParameterType, key: key);
 
                 list =

--- a/src/Grace/DependencyInjection/Impl/Expressions/MethodInvokeExpressionCreator.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/MethodInvokeExpressionCreator.cs
@@ -121,13 +121,14 @@ namespace Grace.DependencyInjection.Impl.Expressions
             foreach (var parameter in methodInjection.Method.GetParameters())
             {
                 object key = null;
+                bool isOptinal = false;
 
                 if (request.RequestingScope.ScopeConfiguration.Behaviors.KeyedTypeSelector(parameter.ParameterType))
                 {
                     key = parameter.Name;
                 }
 
-                var found = parameter.ParameterType.IsGenericParameter ||
+                var found = parameter.ParameterType.IsGenericParameter || isOptinal ||
                             request.RequestingScope.CanLocate(parameter.ParameterType, key: key);
 
                 list =
@@ -159,6 +160,16 @@ namespace Grace.DependencyInjection.Impl.Expressions
                 if (scope.ScopeConfiguration.Behaviors.KeyedTypeSelector(parameter.ParameterType))
                 {
                     parameterRequest.SetLocateKey(parameter.Name);
+                }
+
+                var parameterInfo = methodInjectionInfo.ParameterInfos()
+                    .Where(p => p.ParameterName == parameter.Name)
+                    .FirstOrDefault();
+
+                if (parameterInfo != null)
+                {
+                    parameterRequest.SetIsRequired(parameterInfo.IsRequired);
+                    parameterRequest.SetLocateKey(parameterInfo.LocateKey);
                 }
 
                 var result = request.Services.ExpressionBuilder.GetActivationExpression(scope, parameterRequest);

--- a/src/Grace/DependencyInjection/Impl/MethodInjectionInfo.cs
+++ b/src/Grace/DependencyInjection/Impl/MethodInjectionInfo.cs
@@ -1,4 +1,7 @@
 ﻿using System.Reflection;
+using System;
+using Grace.Data.Immutable;
+using System.Collections.Generic;
 
 namespace Grace.DependencyInjection.Impl
 {
@@ -7,9 +10,56 @@ namespace Grace.DependencyInjection.Impl
     /// </summary>
     public class MethodInjectionInfo
     {
+        private ImmutableLinkedList<MethodParameterInfo> _parameterInfo = ImmutableLinkedList<MethodParameterInfo>.Empty;
+
         /// <summary>
         /// Method being injected
         /// </summary>
         public MethodInfo Method { get; set; }
+
+        /// <summary>
+        /// Enumerable of injected method parameters information
+        /// </summary>
+        /// <returns>Enumerable of injected method parameters information</returns>
+        public IEnumerable<MethodParameterInfo> ParameterInfos() => _parameterInfo;
+
+        /// <summary>
+        /// Add a information for injected method parameters
+        /// </summary>
+        /// <param name="methodParameterInfo"></param>
+        public void MethodParameterInfo(MethodParameterInfo methodParameterInfo)
+        {
+            _parameterInfo = _parameterInfo.Add(methodParameterInfo);
+        }
+    }
+
+    /// <summary>
+    /// information for injected method parameters
+    /// </summary>
+    public class MethodParameterInfo
+    {
+        /// <summary>
+        /// injected method parameter name
+        /// </summary>
+        public string ParameterName { get; private set; }
+
+        /// <summary>
+        /// the locate key for injected method parameter
+        /// </summary>
+        public string LocateKey { get; set; }
+
+        /// <summary>
+        /// if the injected method parameter is required
+        /// </summary>
+        public bool IsRequired { get; set; } = true;
+
+        /// <summary>
+        /// constructor for injected method parameters
+        /// </summary>
+        /// <param name="parameterName">the name of the parameter</param>
+        public MethodParameterInfo(string parameterName)
+        {
+            ParameterName = parameterName ?? throw new ArgumentNullException(nameof(parameterName));
+        }
     }
 }

--- a/tests/Grace.Tests/DependencyInjection/MemberInjection/MethodInjectionTests.cs
+++ b/tests/Grace.Tests/DependencyInjection/MemberInjection/MethodInjectionTests.cs
@@ -1,4 +1,10 @@
-﻿using Grace.DependencyInjection;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Grace.Data.Immutable;
+using Grace.DependencyInjection;
+using Grace.DependencyInjection.Exceptions;
+using Grace.DependencyInjection.Impl;
 using Grace.Tests.Classes.Simple;
 using Xunit;
 
@@ -81,6 +87,91 @@ namespace Grace.Tests.DependencyInjection.MemberInjection
             Assert.NotNull(instance);
 
             Assert.Equal(5, instance.Value);
+        }
+
+        [Fact]
+        public void MethodInjection_Specify_Parameter_Info()
+        {
+            var container = new DependencyInjectionContainer();
+
+            container.Configure(c =>
+            {
+                c.AddInspector(new MethodInjectionSpecifyParameterInfoSelector());
+                c.Export<BasicService>().AsKeyed<IBasicService>("Hello");
+            });
+
+            var instance = container.Locate<MethodInjectionClass>();
+
+            Assert.NotNull(instance);
+
+            Assert.NotNull(instance.BasicService);
+            Assert.Null(instance.SecondService);
+        }
+
+        [Fact]
+        public void MethodInjection_Specify_Parameter_Info_Without_Service()
+        {
+            var container = new DependencyInjectionContainer();
+
+            container.Configure(c =>
+            {
+                c.AddInspector(new MethodInjectionSpecifyParameterInfoSelector(true));
+                c.Export<BasicService>().AsKeyed<IBasicService>("Hello");
+            });
+
+            Assert.Throws<LocateException>(() => container.Locate<MethodInjectionClass>());
+        }
+
+        private class MethodInjectionSpecifyParameterInfoSelector : IActivationStrategyInspector, IMemberInjectionSelector
+        {
+            private bool vooDooIsRequired;
+
+            public MethodInjectionSpecifyParameterInfoSelector(bool vooDooIsRequired = false)
+            {
+                this.vooDooIsRequired = vooDooIsRequired;
+            }
+
+            public IEnumerable<MethodInjectionInfo> GetMethods(
+                Type type, 
+                IInjectionScope injectionScope, 
+                IActivationExpressionRequest request)
+            {
+                if (type != typeof(MethodInjectionClass))
+                    return ImmutableLinkedList<MethodInjectionInfo>.Empty;
+
+                var methods = new MethodInjectionInfo[2];
+
+                var injectMethod = type.GetMethod(nameof(MethodInjectionClass.InjectMethod));
+                methods[0] = new MethodInjectionInfo() { Method = injectMethod };
+                methods[0].MethodParameterInfo(new MethodParameterInfo("basicService")
+                {
+                    LocateKey = "Hello",
+                    IsRequired = true,
+                });
+
+                var someOtherMethod = type.GetMethod(nameof(MethodInjectionClass.SomeOtherMethod));
+                methods[1] = new MethodInjectionInfo() { Method = someOtherMethod };
+                methods[1].MethodParameterInfo(new MethodParameterInfo("basicService")
+                {
+                    LocateKey = "VooDoo",
+                    IsRequired = vooDooIsRequired,
+                });
+
+                return methods;
+            }
+
+            public IEnumerable<MemberInjectionInfo> GetPropertiesAndFields(Type type, 
+            IInjectionScope injectionScope, 
+            IActivationExpressionRequest request)
+            {
+                return ImmutableLinkedList<MemberInjectionInfo>.Empty;
+            }
+
+            void IActivationStrategyInspector.Inspect<T>(T strategy)
+            {
+                if (strategy.ActivationType == typeof(MethodInjectionClass))
+                    strategy.GetActivationConfiguration(strategy.ActivationType).MemberInjectionSelector(this);
+            }
         }
     }
 }


### PR DESCRIPTION
I need that be possible to specify the locate key for injected methods parameters, in addition to informing if the parameter is required.

I created a class named 'MethodParameterInfo' and change the class 'MethodInjectionInfo'.

In the 'GetDependenciesForMethod' method, I set the parameterRequest values.