### PR TITLE
Using nameof wherever we can.

### DIFF
--- a/src/Grace.Factory/Impl/DynamicFactoryStrategy.cs
+++ b/src/Grace.Factory/Impl/DynamicFactoryStrategy.cs
@@ -96,7 +96,7 @@ namespace Grace.Factory.Impl
 
             var newStatement = Expression.New(constructor, parameters);
 
-            var setMethod = typeof(IExtraDataContainer).GetRuntimeMethod("SetExtraData",
+            var setMethod = typeof(IExtraDataContainer).GetRuntimeMethod(nameof(IExtraDataContainer.SetExtraData),
                 new[] { typeof(object), typeof(object), typeof(bool) });
 
             var invokeStatement = Expression.Call(request.InjectionContextParameter, setMethod,
@@ -109,7 +109,7 @@ namespace Grace.Factory.Impl
 
         private IKnownValueExpression CreateKnownValueExpression(IActivationExpressionRequest request, Type argType, string valueId, string nameHint = null, int? position = null)
         {
-            var getMethod = typeof(IExtraDataContainer).GetRuntimeMethod("GetExtraData", new[] { typeof(object) });
+            var getMethod = typeof(IExtraDataContainer).GetRuntimeMethod(nameof(IExtraDataContainer.GetExtraData), new[] { typeof(object) });
 
             var callExpression = Expression.Call(request.InjectionContextParameter, getMethod,
                 Expression.Constant(valueId));

--- a/src/Grace.Factory/Impl/DynamicTypeBuilder.cs
+++ b/src/Grace.Factory/Impl/DynamicTypeBuilder.cs
@@ -17,11 +17,11 @@ namespace Grace.Factory.Impl
         private static readonly object BuilderLock = new object();
         private static ModuleBuilder _moduleBuilder;
         private static int _proxyCount = 0;
-        private static MethodInfo CloneMethod = typeof(IInjectionContext).GetRuntimeMethod("Clone",new Type[0]);
-        private static MethodInfo DelegateInvoke = typeof(ActivationStrategyDelegate).GetRuntimeMethod("Invoke",
+        private static MethodInfo CloneMethod = typeof(IInjectionContext).GetRuntimeMethod(nameof(IInjectionContext.Clone),new Type[0]);
+        private static MethodInfo DelegateInvoke = typeof(ActivationStrategyDelegate).GetRuntimeMethod(nameof(ActivationStrategyDelegate.Invoke),
             new[] {typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext)});
         private static MethodInfo SetExtraDataMethod =
-            typeof(IExtraDataContainer).GetRuntimeMethod("SetExtraData", new[] { typeof(object), typeof(object), typeof(bool) });
+            typeof(IExtraDataContainer).GetRuntimeMethod(nameof(IExtraDataContainer.SetExtraData), new[] { typeof(object), typeof(object), typeof(bool) });
 
         /// <summary>
         /// Default constructor

--- a/src/Grace/Data/ReflectionService.cs
+++ b/src/Grace/Data/ReflectionService.cs
@@ -15,7 +15,7 @@ namespace Grace.Data
     public class ReflectionService
     {
         private static readonly MethodInfo ImmutableTreeAdd =
-            typeof(ImmutableHashTree<string, object>).GetRuntimeMethods().First(m => m.Name == "Add");
+            typeof(ImmutableHashTree<string, object>).GetRuntimeMethods().First(m => m.Name == nameof(ImmutableHashTree<string, object>.Add));
 
         private static ImmutableHashTree<Type, PropertyDictionaryDelegate> _propertyDelegates =
             ImmutableHashTree<Type, PropertyDictionaryDelegate>.Empty;
@@ -406,7 +406,7 @@ namespace Grace.Data
                     injectionParameter, delegateParameter).Compile();
         }
 
-        private static readonly MethodInfo _locateMethod = typeof(ILocatorService).GetRuntimeMethod("Locate",
+        private static readonly MethodInfo _locateMethod = typeof(ILocatorService).GetRuntimeMethod(nameof(ILocatorService.Locate),
             new[] { typeof(Type), typeof(object), typeof(ActivationStrategyFilter), typeof(object), typeof(bool) });
     }
 }

--- a/src/Grace/DependencyInjection/Impl/ActivationStrategyCompiler.cs
+++ b/src/Grace/DependencyInjection/Impl/ActivationStrategyCompiler.cs
@@ -283,6 +283,7 @@ namespace Grace.DependencyInjection.Impl
         }
 
 
+        //TODO: Typo in method name.
         protected virtual T CompileExpressionResultToOpitimzed<T>(
             IActivationExpressionResult expressionContext, ParameterExpression[] parameters, Expression[] extraExpressions,
             Expression finalExpression)
@@ -311,7 +312,7 @@ namespace Grace.DependencyInjection.Impl
 
             if (parameterInfos.Length > 3)
             {
-                throw new Exception("Delegat type not supported: " + typeof(T).Name);
+                throw new Exception("Delegate type not supported: " + typeof(T).Name);
             }
 
             if (parameterInfos.Length > 0)

--- a/src/Grace/DependencyInjection/Impl/ActivationStrategyCompiler.cs
+++ b/src/Grace/DependencyInjection/Impl/ActivationStrategyCompiler.cs
@@ -524,7 +524,7 @@ namespace Grace.DependencyInjection.Impl
 
         private void AddInjectionContextExpression(IActivationExpressionResult expressionContext)
         {
-            var method = typeof(IInjectionContextCreator).GetRuntimeMethod("CreateContext",
+            var method = typeof(IInjectionContextCreator).GetRuntimeMethod(nameof(IInjectionContextCreator.CreateContext),
                     new[]
                     {
                         typeof(object)

--- a/src/Grace/DependencyInjection/Impl/CompiledStrategies/CompiledExportStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/CompiledStrategies/CompiledExportStrategy.cs
@@ -103,7 +103,7 @@ namespace Grace.DependencyInjection.Impl.CompiledStrategies
                 newScope = Expression.Variable(typeof(IExportLocatorScope));
 
                 var beginScopeMethod =
-                    typeof(IExportLocatorScope).GetTypeInfo().GetDeclaredMethod("BeginLifetimeScope");
+                    typeof(IExportLocatorScope).GetTypeInfo().GetDeclaredMethod(nameof(IExportLocatorScope.BeginLifetimeScope));
 
                 assignStatement =
                     Expression.Assign(newScope,

--- a/src/Grace/DependencyInjection/Impl/CompiledStrategies/GenericCompiledExportStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/CompiledStrategies/GenericCompiledExportStrategy.cs
@@ -152,7 +152,7 @@ namespace Grace.DependencyInjection.Impl.CompiledStrategies
                 newScope = Expression.Variable(typeof(IExportLocatorScope));
 
                 var beginScopeMethod =
-                    typeof(IExportLocatorScope).GetTypeInfo().GetDeclaredMethod("BeginLifetimeScope");
+                    typeof(IExportLocatorScope).GetTypeInfo().GetDeclaredMethod(nameof(IExportLocatorScope.BeginLifetimeScope));
 
                 assignStatement =
                     Expression.Assign(newScope,

--- a/src/Grace/DependencyInjection/Impl/DynamicArrayLocator.cs
+++ b/src/Grace/DependencyInjection/Impl/DynamicArrayLocator.cs
@@ -62,7 +62,7 @@ namespace Grace.DependencyInjection.Impl
                 var elementType = type.GetTypeInfo().GetElementType();
 
                 var method =
-                    typeof(DynamicArrayLocator).GetRuntimeMethods().FirstOrDefault(m => m.Name == "ArrayCreateMethod");
+                    typeof(DynamicArrayLocator).GetRuntimeMethods().FirstOrDefault(m => m.Name == nameof(ArrayCreateMethod));
 
                 var closedMethod = method.MakeGenericMethod(elementType);
 

--- a/src/Grace/DependencyInjection/Impl/DynamicIEnumerableLocator.cs
+++ b/src/Grace/DependencyInjection/Impl/DynamicIEnumerableLocator.cs
@@ -64,7 +64,7 @@ namespace Grace.DependencyInjection.Impl
                 var elementType = type.GenericTypeArguments[0];
 
                 var method =
-                    typeof(DynamicIEnumerableLocator).GetRuntimeMethods().FirstOrDefault(m => m.Name == "EnumerableCreateMethod");
+                    typeof(DynamicIEnumerableLocator).GetRuntimeMethods().FirstOrDefault(m => m.Name == nameof(EnumerableCreateMethod));
 
                 var closedMethod = method.MakeGenericMethod(elementType);
 

--- a/src/Grace/DependencyInjection/Impl/EnumerableStrategies/ImmutableArrayStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/EnumerableStrategies/ImmutableArrayStrategy.cs
@@ -36,7 +36,7 @@ namespace Grace.DependencyInjection.Impl.EnumerableStrategies
             var listResult = request.Services.ExpressionBuilder.GetActivationExpression(scope, newRequest);
 
             var fromMethod =
-                typeof(ImmutableArray).GetRuntimeMethods().First(m => m.Name == "From" && m.GetParameters().Length == 2);
+                typeof(ImmutableArray).GetRuntimeMethods().First(m => m.Name == nameof(ImmutableArray.From) && m.GetParameters().Length == 2);
 
             var closedMethod = fromMethod.MakeGenericMethod(elementType);
 

--- a/src/Grace/DependencyInjection/Impl/EnumerableStrategies/ImmutableLinkListStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/EnumerableStrategies/ImmutableLinkListStrategy.cs
@@ -35,7 +35,7 @@ namespace Grace.DependencyInjection.Impl.EnumerableStrategies
             var listResult = request.Services.ExpressionBuilder.GetActivationExpression(scope, newRequest);
 
             var createMethod =
-                typeof(ImmutableLinkListStrategy).GetTypeInfo().GetDeclaredMethod("CreateImmutableLinkedList");
+                typeof(ImmutableLinkListStrategy).GetTypeInfo().GetDeclaredMethod(nameof(CreateImmutableLinkedList));
 
             var closedMethod = createMethod.MakeGenericMethod(elementType);
 

--- a/src/Grace/DependencyInjection/Impl/Expressions/ActivationExpressionBuilder.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/ActivationExpressionBuilder.cs
@@ -219,7 +219,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
         /// <returns></returns>
         public virtual IActivationExpressionResult GetValueFromInjectionContext(IInjectionScope scope, IActivationExpressionRequest request)
         {
-            var valueMethod = _contextValueProvider.GetType().GetRuntimeMethod("GetValueFromInjectionContext", new[]
+            var valueMethod = _contextValueProvider.GetType().GetRuntimeMethod(nameof(GetValueFromInjectionContext), new[]
             {
                 typeof(IExportLocatorScope),
                 typeof(StaticInjectionContext),
@@ -413,7 +413,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
 
                 request.RequireExportScope();
 
-                var method = typeof(IExportLocatorScopeExtensions).GetRuntimeMethod("GetInjectionScope", new[] { typeof(IExportLocatorScope) });
+                var method = typeof(IExportLocatorScopeExtensions).GetRuntimeMethod(nameof(IExportLocatorScopeExtensions.GetInjectionScope), new[] { typeof(IExportLocatorScope) });
 
                 var expression = Expression.Call(method, request.ScopeParameter);
 
@@ -456,7 +456,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
             if (request.IsDynamic)
             {
                 var dynamicMethod =
-                    typeof(ActivationExpressionBuilder).GetRuntimeMethod("GetDynamicValue",
+                    typeof(ActivationExpressionBuilder).GetRuntimeMethod(nameof(GetDynamicValue),
                         new[]
                         {
                             typeof(IExportLocatorScope),

--- a/src/Grace/DependencyInjection/Impl/Expressions/ArrayExpressionCreator.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/ArrayExpressionCreator.cs
@@ -83,7 +83,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
                 return arrayInit;
             }
 
-            var openMethod = typeof(ArrayExpressionCreator).GetRuntimeMethods().First(m => m.Name == "SortArray");
+            var openMethod = typeof(ArrayExpressionCreator).GetRuntimeMethods().First(m => m.Name == nameof(SortArray));
 
             var closedMethod = openMethod.MakeGenericMethod(arrayElementType);
 

--- a/src/Grace/DependencyInjection/Impl/Expressions/DisposalScopeExpressionCreator.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/DisposalScopeExpressionCreator.cs
@@ -84,7 +84,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
         /// Method info for add method on IDisposalScope
         /// </summary>
         protected MethodInfo AddMethod=> _addMethod ??
-                    (_addMethod = typeof(IDisposalScope).GetTypeInfo().DeclaredMethods.First(m => m.Name == "AddDisposable" && 
+                    (_addMethod = typeof(IDisposalScope).GetTypeInfo().DeclaredMethods.First(m => m.Name == nameof(IDisposalScope.AddDisposable) && 
                                                                                                   m.GetParameters().Length == 1));
          
 
@@ -92,7 +92,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
         /// Method info for add method on IDisposalScope with cleanup delegate
         /// </summary>
         protected MethodInfo AddMethodWithCleanup => _addMethodWithCleanup ??
-                    (_addMethodWithCleanup = typeof(IDisposalScope).GetTypeInfo().DeclaredMethods.First(m => m.Name == "AddDisposable" && 
+                    (_addMethodWithCleanup = typeof(IDisposalScope).GetTypeInfo().DeclaredMethods.First(m => m.Name == nameof(IDisposalScope.AddDisposable) && 
                                                                                                   m.GetParameters().Length == 2));
     }
 }

--- a/src/Grace/DependencyInjection/Impl/Expressions/DynamicConstructorExpressionCreator.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/DynamicConstructorExpressionCreator.cs
@@ -149,7 +149,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
                 var labelArray = Expression.Constant(testValues.Select(t => t.Item2).ToArray());
 
                 var createErrorStringMethod = typeof(DynamicConstructorExpressionCreator).GetTypeInfo()
-                    .GetDeclaredMethod("CreateMissingErrorMessage");
+                    .GetDeclaredMethod(nameof(CreateMissingErrorMessage));
 
                 testExpressions.Add(Expression.Throw(Expression.New(constructor,
                     Expression.Constant(request.GetStaticInjectionContext()),
@@ -431,13 +431,13 @@ namespace Grace.DependencyInjection.Impl.Expressions
         /// Method to use for can locate
         /// </summary>
         public virtual MethodInfo DynamicCanLocateMethodInfo =>
-            GetType().GetTypeInfo().GetDeclaredMethod("DynamicCanLocate");
+            GetType().GetTypeInfo().GetDeclaredMethod(nameof(DynamicCanLocate));
 
         /// <summary>
         /// Method to use for locate
         /// </summary>
         public virtual MethodInfo DynamicLocateMethodInfo =>
-            GetType().GetTypeInfo().GetDeclaredMethod("DynamicLocate");
+            GetType().GetTypeInfo().GetDeclaredMethod(nameof(DynamicLocate));
 
     }
 }

--- a/src/Grace/DependencyInjection/Impl/Expressions/ExpressionUtilities.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/ExpressionUtilities.cs
@@ -207,7 +207,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
             {
                 return _checkForNullMethodInfo ??
                        (_checkForNullMethodInfo =
-                           typeof(ExpressionUtilities).GetRuntimeMethods().First(m => m.Name == "CheckForNull"));
+                           typeof(ExpressionUtilities).GetRuntimeMethods().First(m => m.Name == nameof(CheckForNull)));
             }
         }
 
@@ -245,7 +245,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
             {
                 return _addToDisposalScopeMethodInfo ??
                        (_addToDisposalScopeMethodInfo =
-                           typeof(ExpressionUtilities).GetRuntimeMethods().First(m => m.Name == "AddToDisposalScope"));
+                           typeof(ExpressionUtilities).GetRuntimeMethods().First(m => m.Name == nameof(AddToDisposalScope)));
             }
         }
         #endregion
@@ -289,7 +289,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
             {
                 return _checkForNullAndAddToDisposalScopeMethodInfo ??
                        (_checkForNullAndAddToDisposalScopeMethodInfo =
-                           typeof(ExpressionUtilities).GetRuntimeMethods().First(m => m.Name == "CheckForNullAndAddToDisposalScope"));
+                           typeof(ExpressionUtilities).GetRuntimeMethods().First(m => m.Name == nameof(CheckForNullAndAddToDisposalScope)));
             }
         }
         #endregion

--- a/src/Grace/DependencyInjection/Impl/Expressions/ExpressionUtilities.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/ExpressionUtilities.cs
@@ -122,7 +122,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
                 if (request.DefaultValue != null)
                 {
                     var method = typeof(ExpressionUtilities).GetRuntimeMethods()
-                           .FirstOrDefault(m => m.Name == "ValueOrDefault");
+                           .FirstOrDefault(m => m.Name == nameof(ValueOrDefault));
 
                     var closedMethod = method.MakeGenericMethod(request.ActivationType);
 
@@ -149,7 +149,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
                 request.RequireDisposalScope();
 
                 var method = typeof(ExpressionUtilities).GetRuntimeMethods()
-                    .FirstOrDefault(m => m.Name == "AddToDisposableScopeOrDefault");
+                    .FirstOrDefault(m => m.Name == nameof(AddToDisposableScopeOrDefault));
 
                 var closedMethod = method.MakeGenericMethod(request.ActivationType);
 

--- a/src/Grace/DependencyInjection/Impl/KnownTypeStrategies/KeyedLocateDelegateStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/KnownTypeStrategies/KeyedLocateDelegateStrategy.cs
@@ -78,7 +78,7 @@ namespace Grace.DependencyInjection.Impl.KnownTypeStrategies
         /// <returns></returns>
         public IActivationExpressionResult GetActivationExpression(IInjectionScope scope, IActivationExpressionRequest request)
         {
-            var openMethod = typeof(KeyedLocateDelegateStrategy).GetRuntimeMethod("CreateKeyedDelegate",
+            var openMethod = typeof(KeyedLocateDelegateStrategy).GetRuntimeMethod(nameof(CreateKeyedDelegate),
                 new[] { typeof(IExportLocatorScope) });
 
             var closedMethod = openMethod.MakeGenericMethod(request.ActivationType.GenericTypeArguments);

--- a/src/Grace/DependencyInjection/Impl/Wrappers/BaseWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/BaseWrapperStrategy.cs
@@ -121,7 +121,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
         public static IKnownValueExpression CreateKnownValueExpression(IActivationExpressionRequest request, Type argType, string valueId, string hintName = null, int? position = null)
         {
-            var getMethod = typeof(IExtraDataContainer).GetRuntimeMethod("GetExtraData", new[] { typeof(object) });
+            var getMethod = typeof(IExtraDataContainer).GetRuntimeMethod(nameof(GetExtraData), new[] { typeof(object) });
 
             var callExpression = Expression.Call(request.InjectionContextParameter, getMethod,
                 Expression.Constant(valueId));

--- a/src/Grace/DependencyInjection/Impl/Wrappers/BaseWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/BaseWrapperStrategy.cs
@@ -121,7 +121,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
         public static IKnownValueExpression CreateKnownValueExpression(IActivationExpressionRequest request, Type argType, string valueId, string hintName = null, int? position = null)
         {
-            var getMethod = typeof(IExtraDataContainer).GetRuntimeMethod(nameof(GetExtraData), new[] { typeof(object) });
+            var getMethod = typeof(IExtraDataContainer).GetRuntimeMethod(nameof(IExtraDataContainer.GetExtraData), new[] { typeof(object) });
 
             var callExpression = Expression.Call(request.InjectionContextParameter, getMethod,
                 Expression.Constant(valueId));

--- a/src/Grace/DependencyInjection/Impl/Wrappers/DelegateFiveArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/DelegateFiveArgWrapperStrategy.cs
@@ -49,7 +49,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
             var closedClass = typeof(DelegateExpression<,,,,,,>).MakeGenericType(list.ToArray());
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateDelegate", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(DelegateExpression<object,object,object,object,object,object,object>.CreateDelegate), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 
@@ -110,7 +110,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
                 _action = request.Services.Compiler.CompileDelegate(scope, activationExpression);
 
-                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod("Func");
+                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod(nameof(FuncClass.Func));
             }
             
             /// <summary>

--- a/src/Grace/DependencyInjection/Impl/Wrappers/DelegateFourArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/DelegateFourArgWrapperStrategy.cs
@@ -49,7 +49,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
             var closedClass = typeof(DelegateExpression<,,,,,>).MakeGenericType(list.ToArray());
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateDelegate", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(DelegateExpression<object,object,object,object,object,object>.CreateDelegate), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
             
@@ -108,7 +108,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
                 _action = request.Services.Compiler.CompileDelegate(scope, activationExpression);
 
-                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod("Func");
+                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod(nameof(FuncClass.Func));
             }
             
             /// <summary>

--- a/src/Grace/DependencyInjection/Impl/Wrappers/DelegateNoArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/DelegateNoArgWrapperStrategy.cs
@@ -48,7 +48,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
             var closedClass = typeof(DelegateExpression<,>).MakeGenericType(list.ToArray());
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateDelegate", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(DelegateExpression<object,object>.CreateDelegate), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 
@@ -94,7 +94,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
                 _action = request.Services.Compiler.CompileDelegate(scope, activationExpression);
 
-                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod("Func");
+                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod(nameof(FuncClass.Func));
             }
 
             /// <summary>

--- a/src/Grace/DependencyInjection/Impl/Wrappers/DelegateOneArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/DelegateOneArgWrapperStrategy.cs
@@ -51,7 +51,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
             var closedClass = typeof(DelegateExpression<,,>).MakeGenericType(list.ToArray());
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateDelegate", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(DelegateExpression<object,object,object>.CreateDelegate), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 
@@ -101,7 +101,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
                 _action = request.Services.Compiler.CompileDelegate(scope, activationExpression);
 
-                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod("Func");
+                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod(nameof(FuncClass.Func));
             }
 
             /// <summary>

--- a/src/Grace/DependencyInjection/Impl/Wrappers/DelegateThreeArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/DelegateThreeArgWrapperStrategy.cs
@@ -50,7 +50,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
             var closedClass = typeof(DelegateExpression<,,,,>).MakeGenericType(list.ToArray());
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateDelegate", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(DelegateExpression<object,object,object,object,object>.CreateDelegate), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 
@@ -106,7 +106,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
                 _action = request.Services.Compiler.CompileDelegate(scope, activationExpression);
 
-                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod("Func");
+                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod(nameof(FuncClass.Func));
             }
             
             /// <summary>

--- a/src/Grace/DependencyInjection/Impl/Wrappers/DelegateTwoArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/DelegateTwoArgWrapperStrategy.cs
@@ -49,7 +49,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
             var closedClass = typeof(DelegateExpression<,,,>).MakeGenericType(list.ToArray());
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateDelegate", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(DelegateExpression<object,object,object,object>.CreateDelegate), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 
@@ -102,7 +102,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
 
                 _action = request.Services.Compiler.CompileDelegate(scope, activationExpression);
 
-                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod("Func");
+                _funcMethodInfo = typeof(FuncClass).GetTypeInfo().GetDeclaredMethod(nameof(FuncClass.Func));
             }
             
             /// <summary>

--- a/src/Grace/DependencyInjection/Impl/Wrappers/FuncFiveArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/FuncFiveArgWrapperStrategy.cs
@@ -45,7 +45,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(FuncExpression<,,,,,>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateFunc", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(FuncExpression<object,object,object,object,object,object>.CreateFunc), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/FuncFourArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/FuncFourArgWrapperStrategy.cs
@@ -45,7 +45,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(FuncExpression<,,,,>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateFunc", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(FuncExpression<object,object,object,object,object>.CreateFunc), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/FuncOneArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/FuncOneArgWrapperStrategy.cs
@@ -46,7 +46,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(FuncExpression<,>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateFunc", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(FuncExpression<object,object>.CreateFunc), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/FuncThreeArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/FuncThreeArgWrapperStrategy.cs
@@ -46,7 +46,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(FuncExpression<,,,>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateFunc", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(FuncExpression<object,object,object,object>.CreateFunc), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/FuncTwoArgWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/FuncTwoArgWrapperStrategy.cs
@@ -45,7 +45,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(FuncExpression<,,>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateFunc", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(FuncExpression<object,object,object>.CreateFunc), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, request.Services.InjectionContextCreator, this);
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/FuncWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/FuncWrapperStrategy.cs
@@ -42,7 +42,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(FuncExpression<>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateFunc", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(FuncExpression<object>.CreateFunc), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, this);
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/LazyMetadataWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/LazyMetadataWrapperStrategy.cs
@@ -83,7 +83,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(LazyExpression<,>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateLazy", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(LazyExpression<object,object>.CreateLazy), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var wrappedStrategy = request.GetWrappedStrategy();
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/LazyWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/LazyWrapperStrategy.cs
@@ -46,7 +46,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(LazyExpression<>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateLazy", new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(LazyExpression<object>.CreateLazy), new[] { typeof(IExportLocatorScope), typeof(IDisposalScope), typeof(IInjectionContext) });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, this);
 

--- a/src/Grace/DependencyInjection/Impl/Wrappers/TypedActivationStrategyDelegateWrapperStrategy.cs
+++ b/src/Grace/DependencyInjection/Impl/Wrappers/TypedActivationStrategyDelegateWrapperStrategy.cs
@@ -44,7 +44,7 @@ namespace Grace.DependencyInjection.Impl.Wrappers
         {
             var closedClass = typeof(TypedDelegateExpression<>).MakeGenericType(request.ActivationType.GenericTypeArguments);
 
-            var closedMethod = closedClass.GetRuntimeMethod("CreateFunc", new Type[] {  });
+            var closedMethod = closedClass.GetRuntimeMethod(nameof(TypedDelegateExpression<object>.CreateFunc), new Type[] {  });
 
             var instance = Activator.CreateInstance(closedClass, scope, request, this);
 

--- a/src/Grace/DependencyInjection/Lifestyle/DeferredSingletonLifestyle.cs
+++ b/src/Grace/DependencyInjection/Lifestyle/DeferredSingletonLifestyle.cs
@@ -44,7 +44,7 @@ namespace Grace.DependencyInjection.Lifestyle
             _activationDelegate =
                 request.Services.Compiler.CompileDelegate(scope, activationExpression(newRequest));
 
-            var singletonMethod = GetType().GetTypeInfo().GetDeclaredMethod("SingletonActivation");
+            var singletonMethod = GetType().GetTypeInfo().GetDeclaredMethod(nameof(SingletonActivation));
 
             ConstantExpression = Expression.Call(Expression.Constant(this), singletonMethod,
                 request.Constants.ScopeParameter, request.Constants.RootDisposalScope,

--- a/src/Grace/DependencyInjection/Lifestyle/SingletonPerAncestor.cs
+++ b/src/Grace/DependencyInjection/Lifestyle/SingletonPerAncestor.cs
@@ -59,7 +59,7 @@ namespace Grace.DependencyInjection.Lifestyle
 
             if (_guaranteeOnlyOne)
             {
-                var openMethod = typeof(SingletonPerAncestor).GetRuntimeMethod("GetValueGuaranteeOnce",
+                var openMethod = typeof(SingletonPerAncestor).GetRuntimeMethod(nameof(GetValueGuaranteeOnce),
                     new[]
                     {
                         typeof(IExportLocatorScope),
@@ -73,7 +73,7 @@ namespace Grace.DependencyInjection.Lifestyle
             }
             else
             {
-                var openMethod = typeof(SingletonPerAncestor).GetRuntimeMethod("GetValue",
+                var openMethod = typeof(SingletonPerAncestor).GetRuntimeMethod(nameof(GetValue),
                     new[]
                     {
                         typeof(IExportLocatorScope),

--- a/src/Grace/DependencyInjection/Lifestyle/SingletonPerKeyLifestyle.cs
+++ b/src/Grace/DependencyInjection/Lifestyle/SingletonPerKeyLifestyle.cs
@@ -10,7 +10,7 @@ namespace Grace.DependencyInjection.Lifestyle
     public class SingletonPerKeyLifestyle : ICompiledLifestyle
     {
         private static MethodInfo getInstanceMethodInfo =
-            typeof(SingletonPerKeyLifestyle).GetTypeInfo().GetDeclaredMethod("GetInstance");
+            typeof(SingletonPerKeyLifestyle).GetTypeInfo().GetDeclaredMethod(nameof(GetInstance));
 
         private Func<IExportLocatorScope, IInjectionContext, object> _keyFunc;
         private ImmutableHashTree<object,object> _singletons = ImmutableHashTree<object, object>.Empty;

--- a/src/Grace/DependencyInjection/Lifestyle/SingletonPerNamedScopeLifestyle.cs
+++ b/src/Grace/DependencyInjection/Lifestyle/SingletonPerNamedScopeLifestyle.cs
@@ -69,7 +69,7 @@ namespace Grace.DependencyInjection.Lifestyle
             }
 
             var getValueFromScopeMethod =
-                typeof(SingletonPerNamedScopeLifestyle).GetRuntimeMethod("GetValueFromScope",
+                typeof(SingletonPerNamedScopeLifestyle).GetRuntimeMethod(nameof(GetValueFromScope),
                     new[]
                     {
                         typeof(IExportLocatorScope),

--- a/src/Grace/DependencyInjection/Lifestyle/SingletonPerObjectGraph.cs
+++ b/src/Grace/DependencyInjection/Lifestyle/SingletonPerObjectGraph.cs
@@ -53,7 +53,7 @@ namespace Grace.DependencyInjection.Lifestyle
 
             if (_guaranteeOnlyOne)
             {
-                var openMethod = typeof(SingletonPerObjectGraph).GetRuntimeMethod("GetValueGuaranteeOnce",
+                var openMethod = typeof(SingletonPerObjectGraph).GetRuntimeMethod(nameof(GetValueGuaranteeOnce),
                     new[]
                     {
                         typeof(IExportLocatorScope),
@@ -67,7 +67,7 @@ namespace Grace.DependencyInjection.Lifestyle
             }
             else
             {
-                var openMethod = typeof(SingletonPerObjectGraph).GetRuntimeMethod("GetValue",
+                var openMethod = typeof(SingletonPerObjectGraph).GetRuntimeMethod(nameof(GetValue),
                     new[]
                     {
                         typeof(IExportLocatorScope),

--- a/src/Grace/DependencyInjection/Lifestyle/SingletonPerScopeLifestyle.cs
+++ b/src/Grace/DependencyInjection/Lifestyle/SingletonPerScopeLifestyle.cs
@@ -93,7 +93,7 @@ namespace Grace.DependencyInjection.Lifestyle
                 }
                 else
                 {
-                    var openMethod = GetType().GetTypeInfo().GetDeclaredMethod("CompileFuncDelage");
+                    var openMethod = GetType().GetTypeInfo().GetDeclaredMethod(nameof(CompileFuncDelage));
 
                     var closed = openMethod.MakeGenericMethod(newResult.Expression.Type);
 
@@ -107,7 +107,7 @@ namespace Grace.DependencyInjection.Lifestyle
 
             if (ThreadSafe)
             {
-                var getValueFromScopeMethod = typeof(SingletonPerScopeLifestyle).GetRuntimeMethod("GetValueFromScopeThreadSafe", new[]
+                var getValueFromScopeMethod = typeof(SingletonPerScopeLifestyle).GetRuntimeMethod(nameof(GetValueFromScopeThreadSafe), new[]
                     {
                         typeof(IExportLocatorScope),
                         typeof(ActivationStrategyDelegate),
@@ -132,7 +132,7 @@ namespace Grace.DependencyInjection.Lifestyle
                 if (invokeMethodFastLane)
                 {
                     var getOrCreateMethod = typeof(IExportLocatorScope).GetTypeInfo()
-                        .GetDeclaredMethods("GetOrCreateScopedService").First(m => m.GetParameters().Length == 2);
+                        .GetDeclaredMethods(nameof(IExportLocatorScope.GetOrCreateScopedService)).First(m => m.GetParameters().Length == 2);
 
                     var closedMethod = getOrCreateMethod.MakeGenericMethod(request.ActivationType);
 
@@ -141,7 +141,7 @@ namespace Grace.DependencyInjection.Lifestyle
                 }
                 else
                 {
-                    var getOrCreateMethod = typeof(IExportLocatorScope).GetRuntimeMethod("GetOrCreateScopedService",
+                    var getOrCreateMethod = typeof(IExportLocatorScope).GetRuntimeMethod(nameof(IExportLocatorScope.GetOrCreateScopedService),
                         new[] {typeof(int), typeof(ActivationStrategyDelegate), typeof(IInjectionContext)});
 
                     var closedMethod = getOrCreateMethod.MakeGenericMethod(request.ActivationType);

--- a/src/Grace/DependencyInjection/Lifestyle/WeakSingletonLifestyle.cs
+++ b/src/Grace/DependencyInjection/Lifestyle/WeakSingletonLifestyle.cs
@@ -49,7 +49,7 @@ namespace Grace.DependencyInjection.Lifestyle
                 Interlocked.CompareExchange(ref _delegate, newDelegate, null);
             }
 
-            var getMethod = typeof(WeakSingletonLifestyle).GetRuntimeMethod("GetValue", new[] {typeof(IInjectionScope)});
+            var getMethod = typeof(WeakSingletonLifestyle).GetRuntimeMethod(nameof(GetValue), new[] {typeof(IInjectionScope)});
 
             var closedMethod = getMethod.MakeGenericMethod(request.ActivationType);
 

--- a/tests/Grace.Tests/DependencyInjection/AddOns/MissingDependencyExpressionProviderTests.cs
+++ b/tests/Grace.Tests/DependencyInjection/AddOns/MissingDependencyExpressionProviderTests.cs
@@ -75,7 +75,7 @@ namespace Grace.Tests.DependencyInjection.AddOns
                     key = ((string)key).ToLowerInvariant();
                 }
 
-                var locateFromChildMethod = GetType().GetTypeInfo().GetDeclaredMethod("LocateFromChildContainer");
+                var locateFromChildMethod = GetType().GetTypeInfo().GetDeclaredMethod(nameof(LocateFromChildContainer));
 
                 Expression expression = Expression.Call(Expression.Constant(this),
                     locateFromChildMethod,

--- a/tests/Grace.Tests/DependencyInjection/ConstructorSelection/TimedConstructorSelectionMethod.cs
+++ b/tests/Grace.Tests/DependencyInjection/ConstructorSelection/TimedConstructorSelectionMethod.cs
@@ -63,10 +63,10 @@ namespace Grace.Tests.DependencyInjection.ConstructorSelection
         }
         
         private MethodInfo PreBuildUpMethodInfo =>
-            _preMethodInfo ?? (_preMethodInfo = GetType().GetMethod("PreBuildUp"));
+            _preMethodInfo ?? (_preMethodInfo = GetType().GetMethod(nameof(PreBuildUp)));
 
         private MethodInfo PostBuildUpMethodInfo =>
-            _postMethodInfo ?? (_postMethodInfo = GetType().GetMethod("PostBuildUp"));
+            _postMethodInfo ?? (_postMethodInfo = GetType().GetMethod(nameof(PostBuildUp)));
 
         public virtual object PreBuildUp(StaticInjectionContext staticContext, IExportLocatorScope scope,
             IInjectionContext injectionContext)

--- a/tests/Grace.Tests/DependencyInjection/Helpers/MembersThatTests.cs
+++ b/tests/Grace.Tests/DependencyInjection/Helpers/MembersThatTests.cs
@@ -17,10 +17,10 @@ namespace Grace.Tests.DependencyInjection.Helpers
         [Fact]
         public void MembersThat_Match()
         {
-            Func<MemberInfo, bool> filter = MembersThat.Match(m => m.Name == "Count");
+            Func<MemberInfo, bool> filter = MembersThat.Match(m => m.Name == nameof(MemberClass.Count));
 
-            var countMember = typeof(MemberClass).GetProperty("Count");
-            var customStringMember = typeof(MemberClass).GetProperty("CustomString");
+            var countMember = typeof(MemberClass).GetProperty(nameof(MemberClass.Count));
+            var customStringMember = typeof(MemberClass).GetProperty(nameof(MemberClass.CustomString));
 
             Assert.True(filter(countMember));
             Assert.False(filter(customStringMember));

--- a/tests/Grace.Tests/DependencyInjection/Lifestyle/CustomSingletonLifestyleTests.cs
+++ b/tests/Grace.Tests/DependencyInjection/Lifestyle/CustomSingletonLifestyleTests.cs
@@ -46,7 +46,7 @@ namespace Grace.Tests.DependencyInjection.Lifestyle
 
                 _activationDelegate = request.Services.Compiler.CompileDelegate(scope, activationExpression(newRequest));
 
-                var singletonMethod = GetType().GetTypeInfo().GetDeclaredMethod("SingletonActivation");
+                var singletonMethod = GetType().GetTypeInfo().GetDeclaredMethod(nameof(SingletonActivation));
 
                 ConstantExpression = Expression.Call(Expression.Constant(this), singletonMethod,
                     request.Constants.ScopeParameter, request.Constants.RootDisposalScope,

--- a/tests/Grace.Tests/ThridParty/Optional/OptionalTests.cs
+++ b/tests/Grace.Tests/ThridParty/Optional/OptionalTests.cs
@@ -221,7 +221,7 @@ namespace Grace.Tests.ThridParty.Optional
 
             var callExpression = Expression.Call(
                 Expression.Constant(factory),
-                factory.GetType().GetMethod("CreateOptional"),
+                factory.GetType().GetMethod(nameof(GraceOptionalFactory<object>.CreateOptional)),
                 request.ScopeParameter,
                 request.DisposalScopeExpression,
                 request.InjectionContextParameter);


### PR DESCRIPTION
Resolves ipjohnson/Grace#176
Just skimmed through the code, but I'm sure I missed some magic strings. This should be the bulk of it though.
There's a certain level of ugliness I bet you'll frown upon, like the `DelegateExpression<object,object,object,object,object>` weirdness. I personally still prefer it over magic strings, but each to their own... So let me know if you can live with the ugliness or not.