### PR TITLE
Removing some double-casting from ImmutableArray.

### DIFF
--- a/src/Grace/Data/Immutable/ImmutableArray.cs
+++ b/src/Grace/Data/Immutable/ImmutableArray.cs
@@ -291,9 +291,9 @@ namespace Grace.Data.Immutable
         /// <returns></returns>
         public override bool Equals(object obj)
         {
-            if (obj is ImmutableArray<T>)
+            if (obj is ImmutableArray<T> immutableArray)
             {
-                return Equals((ImmutableArray<T>)obj, this);
+                return Equals(immutableArray, this);
             }
 
             return false;
@@ -323,9 +323,9 @@ namespace Grace.Data.Immutable
         {
             var compareArray = other as Array;
 
-            if (compareArray == null && other is ImmutableArray<T>)
+            if (compareArray == null && other is ImmutableArray<T> immutableArray)
             {
-                compareArray = ((ImmutableArray<T>)other)._list;
+                compareArray = immutableArray._list;
 
                 if (compareArray == null && _list == null)
                 {
@@ -393,9 +393,9 @@ namespace Grace.Data.Immutable
         {
             var compareArray = other as Array;
 
-            if (compareArray == null && other is ImmutableArray<T>)
+            if (compareArray == null && other is ImmutableArray<T> immutableArray)
             {
-                compareArray = ((ImmutableArray<T>)other)._list;
+                compareArray = immutableArray._list;
 
                 if (compareArray == null && _list == null)
                 {
@@ -429,7 +429,7 @@ namespace Grace.Data.Immutable
         /// </summary>
         /// <param name="left">left side of statement</param>
         /// <param name="right">right side of statement</param>
-        /// <returns>true if euqal</returns>
+        /// <returns>true if equal</returns>
         public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right)
         {
             return left.Equals(right);


### PR DESCRIPTION
As far as I'm aware, `is` uses `isinst` opcode under the hood, which only differs from the `castclass` opcode that explicit cast uses when the type check fails.
That would mean the type cast is already performed, so there's no need to cast the object again. We can simply get a reference and use it with the `obj is Foo foo` pattern.

I realize this is really nitpicking even if I'm correct about the behavior, but I was just reading through the library to get a basic grip of how things work, and I figured I'd send a useless PR to squeeze out 1 more cycle from the CPU.