### PR TITLE
Added support for IAsyncDisposable.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ artifacts:
 - path: Grace*.nupkg
   name: Grace
 image:
-- Visual Studio 2017
+- Visual Studio 2019
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 7.2.1
+  build_version: 8.0.0
   Version: $(build_version)
   COVERALLS_REPO_TOKEN:
     secure: +OWHMxYHaMp6iRNNLZcMZq423PhYWxMky+B2C0p3U8v7tpdoKRMzWZKJ1LuYO60O

--- a/src/Grace/DependencyInjection/IDisposalScope.cs
+++ b/src/Grace/DependencyInjection/IDisposalScope.cs
@@ -5,20 +5,42 @@ namespace Grace.DependencyInjection
     /// <summary>
     /// Represents a scope that holds disposable object
     /// </summary>
-    public interface IDisposalScope : IDisposable
+    public interface IDisposalScope
+#if NETSTANDARD2_1
+        : IDisposable, IAsyncDisposable
+#else
+        : IDisposable
+#endif
     {
+#if NETSTANDARD2_1
+        /// <summary>
+        /// Add an object for disposal tracking
+        /// </summary>
+        /// <param name="disposable">object to track for async disposal</param>
+        T AddAsyncDisposable<T>(T disposable)
+            where T : IAsyncDisposable;
 
         /// <summary>
         /// Add an object for disposal tracking
         /// </summary>
+        /// <param name="disposable">object to track for async disposal</param>
+        /// <param name="cleanupDelegate">logic that will be run directly before the object is disposed</param>
+        T AddAsyncDisposable<T>(T disposable, Action<T> cleanupDelegate)
+            where T : IAsyncDisposable;
+#endif
+        /// <summary>
+        /// Add an object for disposal tracking
+        /// </summary>
         /// <param name="disposable">object to track for disposal</param>
-        T AddDisposable<T>(T disposable) where T : IDisposable;
+        T AddDisposable<T>(T disposable)
+            where T : IDisposable;
 
         /// <summary>
         /// Add an object for disposal tracking
         /// </summary>
         /// <param name="disposable">object to track for disposal</param>
         /// <param name="cleanupDelegate">logic that will be run directly before the object is disposed</param>
-        T AddDisposable<T>(T disposable, Action<T> cleanupDelegate) where T : IDisposable;
+        T AddDisposable<T>(T disposable, Action<T> cleanupDelegate)
+            where T : IDisposable;
     }
 }

--- a/src/Grace/DependencyInjection/Impl/DisposalScope.cs
+++ b/src/Grace/DependencyInjection/Impl/DisposalScope.cs
@@ -1,8 +1,231 @@
 ﻿using System;
 using System.Threading;
+#if NETSTANDARD2_1
+using System.Threading.Tasks;
+#endif
 
 namespace Grace.DependencyInjection.Impl
 {
+#if NETSTANDARD2_1
+    /// <summary>
+    /// class for tracking and disposing objects
+    /// </summary>
+    public class DisposalScope : IDisposalScope
+    {
+        /// <summary>
+        /// For memory allocation and execution performance I've written a one off linked list to track items for disposal
+        /// </summary>
+        private class DisposeEntry
+        {
+            /// <summary>
+            /// Item to be disposed. Can be either IDisposable or IAsyncDisposable
+            /// </summary>
+            public object DisposeItem;
+
+            /// <summary>
+            /// Cleanup delegate that was passed in, this is a wrapper around the original delegate that was passed in
+            /// </summary>
+            public Action CleanupDelegate;
+
+            /// <summary>
+            /// Next entry to dispose
+            /// </summary>
+            public DisposeEntry Next;
+
+            /// <summary>
+            /// Empty entry
+            /// </summary>
+            public static readonly DisposeEntry Empty = new DisposeEntry();
+        }
+
+        /// <summary>
+        /// Internal list of disposal entries
+        /// </summary>
+        private DisposeEntry _entry = DisposeEntry.Empty;
+
+        /// <summary>
+        /// Dispose of scope
+        /// </summary>
+        public virtual void Dispose()
+        {
+            var entry = Interlocked.Exchange(ref _entry, DisposeEntry.Empty);
+
+            while (!ReferenceEquals(entry, DisposeEntry.Empty))
+            {
+                entry.CleanupDelegate?.Invoke();
+                (entry.DisposeItem as IDisposable)?.Dispose();
+
+                entry = entry.Next;
+            }
+        }
+
+        /// <summary>
+        /// Async Dispose of scope
+        /// </summary>
+        public virtual async ValueTask DisposeAsync()
+        {
+            var entry = Interlocked.Exchange(ref _entry, DisposeEntry.Empty);
+
+            while (!ReferenceEquals(entry, DisposeEntry.Empty))
+            {
+                entry.CleanupDelegate?.Invoke();
+                switch (entry.DisposeItem)
+                {
+                    case IAsyncDisposable asyncDisposable:
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        break;
+                    case IDisposable disposable:
+                        disposable.Dispose();
+                        break;
+                    default: 
+                        //highly unlikely case, but a good indication of DisposalScope misuse.
+                        throw new InvalidOperationException($"{nameof(entry.DisposeItem)} of type {entry.DisposeItem.GetType()} is neither IDisposable nor IAsyncDisposable.");
+                }
+
+                entry = entry.Next;
+            }
+        }
+
+        /// <summary>
+        /// Add an object for disposal tracking
+        /// </summary>
+        /// <param name="disposable">object to track for disposal</param>
+        public T AddDisposable<T>(T disposable)
+            where T : IDisposable
+        {
+            var current = _entry;
+
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, new DisposeEntry
+            {
+                DisposeItem =
+                    disposable,
+                Next = current
+            }, current), current))
+            {
+                return disposable;
+            }
+
+            return SwapWaitAdd(disposable);
+        }
+
+        /// <summary>
+        /// Add an object for disposal tracking
+        /// </summary>
+        /// <param name="disposable">object to track for disposal</param>
+        public T AddAsyncDisposable<T>(T disposable)
+            where T : IAsyncDisposable
+        {
+            var current = _entry;
+
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, new DisposeEntry
+            {
+                DisposeItem =
+                    disposable,
+                Next = current
+            }, current), current))
+            {
+                return disposable;
+            }
+
+            return SwapWaitAdd(disposable);
+        }
+
+        /// <summary>
+        /// Add an object for disposal tracking
+        /// </summary>
+        /// <param name="disposable">disposable object to track</param>
+        /// <param name="cleanupDelegate">logic that will be run directly before the object is disposed</param>
+        public T AddDisposable<T>(T disposable, Action<T> cleanupDelegate)
+            where T : IDisposable
+        {
+            DisposeEntry entry;
+
+            var current = _entry;
+
+            if (cleanupDelegate == null)
+            {
+                entry = new DisposeEntry {DisposeItem = disposable, Next = current};
+            }
+            else
+            {
+                entry = new DisposeEntry
+                {
+                    DisposeItem = disposable,
+                    CleanupDelegate = () => cleanupDelegate(disposable),
+                    Next = current
+                };
+            }
+
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, entry, current), current))
+            {
+                return disposable;
+            }
+
+            SwapWaitAdd(entry);
+
+            return disposable;
+        }
+
+        /// <summary>
+        /// Add an object for disposal tracking
+        /// </summary>
+        /// <param name="disposable">disposable object to track</param>
+        /// <param name="cleanupDelegate">logic that will be run directly before the object is disposed</param>
+        public T AddAsyncDisposable<T>(T disposable, Action<T> cleanupDelegate)
+            where T : IAsyncDisposable
+        {
+            DisposeEntry entry;
+
+            var current = _entry;
+
+            if (cleanupDelegate == null)
+            {
+                entry = new DisposeEntry {DisposeItem = disposable, Next = current};
+            }
+            else
+            {
+                entry = new DisposeEntry
+                {
+                    DisposeItem = disposable,
+                    CleanupDelegate = () => cleanupDelegate(disposable),
+                    Next = current
+                };
+            }
+
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, entry, current), current))
+            {
+                return disposable;
+            }
+
+            SwapWaitAdd(entry);
+
+            return disposable;
+        }
+
+        private T SwapWaitAdd<T>(T value)
+        {
+            SwapWaitAdd(new DisposeEntry {DisposeItem = value, Next = _entry});
+
+            return value;
+        }
+
+        private void SwapWaitAdd(DisposeEntry entry)
+        {
+            var spinWait = new SpinWait();
+
+            spinWait.SpinOnce();
+
+            var current = entry.Next = _entry;
+
+            while (!ReferenceEquals(Interlocked.CompareExchange(ref _entry, entry, current), current))
+            {
+                spinWait.SpinOnce();
+
+                current = entry.Next = _entry;
+            }
+        }
+    }
+#else
     /// <summary>
     /// class for tracking and disposing objects
     /// </summary>
@@ -33,7 +256,7 @@ namespace Grace.DependencyInjection.Impl
             /// </summary>
             public static readonly DisposeEntry Empty = new DisposeEntry();
         }
-        
+
         /// <summary>
         /// Internal list of disposal entries
         /// </summary>
@@ -45,7 +268,7 @@ namespace Grace.DependencyInjection.Impl
         public virtual void Dispose()
         {
             var entry = Interlocked.Exchange(ref _entry, DisposeEntry.Empty);
-            
+
             while (!ReferenceEquals(entry, DisposeEntry.Empty))
             {
                 entry.CleanupDelegate?.Invoke();
@@ -59,11 +282,14 @@ namespace Grace.DependencyInjection.Impl
         /// Add an object for disposal tracking
         /// </summary>
         /// <param name="disposable">object to track for disposal</param>
-        public T AddDisposable<T>(T disposable) where T : IDisposable
+        public T AddDisposable<T>(T disposable)
+            where T : IDisposable
         {
             var current = _entry;
 
-            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, new DisposeEntry { DisposeItem = disposable, Next = current }, current), current))
+            if (ReferenceEquals(
+                Interlocked.CompareExchange(ref _entry, new DisposeEntry {DisposeItem = disposable, Next = current},
+                    current), current))
             {
                 return disposable;
             }
@@ -76,7 +302,8 @@ namespace Grace.DependencyInjection.Impl
         /// </summary>
         /// <param name="disposable">disposable object to track</param>
         /// <param name="cleanupDelegate">logic that will be run directly before the object is disposed</param>
-        public T AddDisposable<T>(T disposable, Action<T> cleanupDelegate) where T : IDisposable
+        public T AddDisposable<T>(T disposable, Action<T> cleanupDelegate)
+            where T : IDisposable
         {
             DisposeEntry entry;
 
@@ -84,7 +311,7 @@ namespace Grace.DependencyInjection.Impl
 
             if (cleanupDelegate == null)
             {
-                entry = new DisposeEntry { DisposeItem = disposable, Next = current };
+                entry = new DisposeEntry {DisposeItem = disposable, Next = current};
             }
             else
             {
@@ -95,7 +322,7 @@ namespace Grace.DependencyInjection.Impl
                     Next = current
                 };
             }
-            
+
             if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, entry, current), current))
             {
                 return disposable;
@@ -106,7 +333,8 @@ namespace Grace.DependencyInjection.Impl
             return disposable;
         }
 
-        private T SwapWaitAdd<T>(T value) where T : IDisposable
+        private T SwapWaitAdd<T>(T value)
+            where T : IDisposable
         {
             SwapWaitAdd(new DisposeEntry {DisposeItem = value, Next = _entry});
 
@@ -129,5 +357,5 @@ namespace Grace.DependencyInjection.Impl
             }
         }
     }
+#endif
 }
-

--- a/src/Grace/DependencyInjection/Impl/DisposalScope.cs
+++ b/src/Grace/DependencyInjection/Impl/DisposalScope.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 
 namespace Grace.DependencyInjection.Impl
 {
-#if NETSTANDARD2_1
     /// <summary>
     /// class for tracking and disposing objects
     /// </summary>
@@ -43,22 +42,8 @@ namespace Grace.DependencyInjection.Impl
         /// </summary>
         private DisposeEntry _entry = DisposeEntry.Empty;
 
-        /// <summary>
-        /// Dispose of scope
-        /// </summary>
-        public virtual void Dispose()
-        {
-            var entry = Interlocked.Exchange(ref _entry, DisposeEntry.Empty);
 
-            while (!ReferenceEquals(entry, DisposeEntry.Empty))
-            {
-                entry.CleanupDelegate?.Invoke();
-                (entry.DisposeItem as IDisposable)?.Dispose();
-
-                entry = entry.Next;
-            }
-        }
-
+#if NETSTANDARD2_1
         /// <summary>
         /// Async Dispose of scope
         /// </summary>
@@ -77,35 +62,14 @@ namespace Grace.DependencyInjection.Impl
                     case IDisposable disposable:
                         disposable.Dispose();
                         break;
-                    default: 
+                    default:
                         //highly unlikely case, but a good indication of DisposalScope misuse.
-                        throw new InvalidOperationException($"{nameof(entry.DisposeItem)} of type {entry.DisposeItem.GetType()} is neither IDisposable nor IAsyncDisposable.");
+                        throw new InvalidOperationException(
+                            $"{nameof(entry.DisposeItem)} of type {entry.DisposeItem.GetType()} is neither IDisposable nor IAsyncDisposable.");
                 }
 
                 entry = entry.Next;
             }
-        }
-
-        /// <summary>
-        /// Add an object for disposal tracking
-        /// </summary>
-        /// <param name="disposable">object to track for disposal</param>
-        public T AddDisposable<T>(T disposable)
-            where T : IDisposable
-        {
-            var current = _entry;
-
-            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, new DisposeEntry
-            {
-                DisposeItem =
-                    disposable,
-                Next = current
-            }, current), current))
-            {
-                return disposable;
-            }
-
-            return SwapWaitAdd(disposable);
         }
 
         /// <summary>
@@ -135,42 +99,6 @@ namespace Grace.DependencyInjection.Impl
         /// </summary>
         /// <param name="disposable">disposable object to track</param>
         /// <param name="cleanupDelegate">logic that will be run directly before the object is disposed</param>
-        public T AddDisposable<T>(T disposable, Action<T> cleanupDelegate)
-            where T : IDisposable
-        {
-            DisposeEntry entry;
-
-            var current = _entry;
-
-            if (cleanupDelegate == null)
-            {
-                entry = new DisposeEntry {DisposeItem = disposable, Next = current};
-            }
-            else
-            {
-                entry = new DisposeEntry
-                {
-                    DisposeItem = disposable,
-                    CleanupDelegate = () => cleanupDelegate(disposable),
-                    Next = current
-                };
-            }
-
-            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, entry, current), current))
-            {
-                return disposable;
-            }
-
-            SwapWaitAdd(entry);
-
-            return disposable;
-        }
-
-        /// <summary>
-        /// Add an object for disposal tracking
-        /// </summary>
-        /// <param name="disposable">disposable object to track</param>
-        /// <param name="cleanupDelegate">logic that will be run directly before the object is disposed</param>
         public T AddAsyncDisposable<T>(T disposable, Action<T> cleanupDelegate)
             where T : IAsyncDisposable
         {
@@ -180,7 +108,7 @@ namespace Grace.DependencyInjection.Impl
 
             if (cleanupDelegate == null)
             {
-                entry = new DisposeEntry {DisposeItem = disposable, Next = current};
+                entry = new DisposeEntry { DisposeItem = disposable, Next = current };
             }
             else
             {
@@ -201,66 +129,7 @@ namespace Grace.DependencyInjection.Impl
 
             return disposable;
         }
-
-        private T SwapWaitAdd<T>(T value)
-        {
-            SwapWaitAdd(new DisposeEntry {DisposeItem = value, Next = _entry});
-
-            return value;
-        }
-
-        private void SwapWaitAdd(DisposeEntry entry)
-        {
-            var spinWait = new SpinWait();
-
-            spinWait.SpinOnce();
-
-            var current = entry.Next = _entry;
-
-            while (!ReferenceEquals(Interlocked.CompareExchange(ref _entry, entry, current), current))
-            {
-                spinWait.SpinOnce();
-
-                current = entry.Next = _entry;
-            }
-        }
-    }
-#else
-    /// <summary>
-    /// class for tracking and disposing objects
-    /// </summary>
-    public class DisposalScope : IDisposalScope
-    {
-        /// <summary>
-        /// For memory allocation and execution performance I've written a one off linked list to track items for disposal
-        /// </summary>
-        private class DisposeEntry
-        {
-            /// <summary>
-            /// Item to be disposed
-            /// </summary>
-            public IDisposable DisposeItem;
-
-            /// <summary>
-            /// Cleanup delegate that was passed in, this is a wrapper around the original delegate that was passed in
-            /// </summary>
-            public Action CleanupDelegate;
-
-            /// <summary>
-            /// Next entry to dispose
-            /// </summary>
-            public DisposeEntry Next;
-
-            /// <summary>
-            /// Empty entry
-            /// </summary>
-            public static readonly DisposeEntry Empty = new DisposeEntry();
-        }
-
-        /// <summary>
-        /// Internal list of disposal entries
-        /// </summary>
-        private DisposeEntry _entry = DisposeEntry.Empty;
+#endif
 
         /// <summary>
         /// Dispose of scope
@@ -272,7 +141,7 @@ namespace Grace.DependencyInjection.Impl
             while (!ReferenceEquals(entry, DisposeEntry.Empty))
             {
                 entry.CleanupDelegate?.Invoke();
-                entry.DisposeItem.Dispose();
+                (entry.DisposeItem as IDisposable)?.Dispose();
 
                 entry = entry.Next;
             }
@@ -287,15 +156,19 @@ namespace Grace.DependencyInjection.Impl
         {
             var current = _entry;
 
-            if (ReferenceEquals(
-                Interlocked.CompareExchange(ref _entry, new DisposeEntry {DisposeItem = disposable, Next = current},
-                    current), current))
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _entry, new DisposeEntry
+            {
+                DisposeItem =
+                    disposable,
+                Next = current
+            }, current), current))
             {
                 return disposable;
             }
 
             return SwapWaitAdd(disposable);
         }
+
 
         /// <summary>
         /// Add an object for disposal tracking
@@ -311,7 +184,7 @@ namespace Grace.DependencyInjection.Impl
 
             if (cleanupDelegate == null)
             {
-                entry = new DisposeEntry {DisposeItem = disposable, Next = current};
+                entry = new DisposeEntry { DisposeItem = disposable, Next = current };
             }
             else
             {
@@ -334,9 +207,8 @@ namespace Grace.DependencyInjection.Impl
         }
 
         private T SwapWaitAdd<T>(T value)
-            where T : IDisposable
         {
-            SwapWaitAdd(new DisposeEntry {DisposeItem = value, Next = _entry});
+            SwapWaitAdd(new DisposeEntry { DisposeItem = value, Next = _entry });
 
             return value;
         }
@@ -357,5 +229,4 @@ namespace Grace.DependencyInjection.Impl
             }
         }
     }
-#endif
 }

--- a/src/Grace/DependencyInjection/Impl/Expressions/ExpressionUtilities.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/ExpressionUtilities.cs
@@ -224,9 +224,15 @@ namespace Grace.DependencyInjection.Impl.Expressions
         /// <returns></returns>
         public static T AddToDisposalScope<T>(IDisposalScope disposalScope, T value)
         {
-            var disposable = value as IDisposable;
 
-            if (disposable != null)
+#if NETSTANDARD2_1
+            if (value is IAsyncDisposable asyncDisposable)
+            {
+                disposalScope.AddAsyncDisposable(asyncDisposable);
+            }
+#endif
+
+            if (value is IDisposable disposable)
             {
                 disposalScope.AddDisposable(disposable);
             }
@@ -268,14 +274,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
                 throw new NullValueProvidedException(context);
             }
 
-            var disposable = value as IDisposable;
-
-            if (disposable != null)
-            {
-                disposalScope.AddDisposable(disposable);
-            }
-
-            return value;
+            return AddToDisposalScope(disposalScope, value);
         }
 
         private static MethodInfo _checkForNullAndAddToDisposalScopeMethodInfo;
@@ -320,14 +319,7 @@ namespace Grace.DependencyInjection.Impl.Expressions
         {
             if (tValue != null)
             {
-                var disposable = tValue as IDisposable;
-
-                if (disposable != null)
-                {
-                    disposalScope.AddDisposable(disposable);
-                }
-
-                return tValue;
+                return AddToDisposalScope(disposalScope, tValue);
             }
 
             return defaultValue;

--- a/src/Grace/DependencyInjection/Impl/Expressions/TypeExpressionBuilder.cs
+++ b/src/Grace/DependencyInjection/Impl/Expressions/TypeExpressionBuilder.cs
@@ -108,11 +108,19 @@ namespace Grace.DependencyInjection.Impl.Expressions
 
         private bool ShouldTrackForDisposable(IInjectionScope scope, TypeActivationConfiguration activationConfiguration)
         {
-            if (activationConfiguration.ActivationType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IDisposable)) == false)
+            var implementedInterfaces = activationConfiguration.ActivationType.GetTypeInfo().ImplementedInterfaces;
+
+#if NETSTANDARD2_1
+            if (!implementedInterfaces.Contains(typeof(IAsyncDisposable)) && !implementedInterfaces.Contains(typeof(IDisposable)))
             {
                 return false;
             }
-
+#else
+            if (implementedInterfaces.Contains(typeof(IDisposable)) == false)
+            {
+                return false;
+            }
+#endif
             if (activationConfiguration.ExternallyOwned)
             {
                 return false;

--- a/src/Grace/Grace.csproj
+++ b/src/Grace/Grace.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Grace is a feature rich Dependency Injection Container</Description>
     <Authors>Ian Johnson</Authors>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;netstandard2.1;net45</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Grace</AssemblyName>

--- a/tests/Grace.Tests/Classes/Simple/DisposableService.cs
+++ b/tests/Grace.Tests/Classes/Simple/DisposableService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Grace.Tests.Classes.Simple
 {
@@ -19,4 +20,21 @@ namespace Grace.Tests.Classes.Simple
 
         public event EventHandler<EventArgs> Disposing;
     }
+
+#if NET5_0
+    public class AsyncDisposableService : IDisposableService, IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            if (Disposing != null)
+            {
+                Disposing(this, EventArgs.Empty);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public event EventHandler<EventArgs> Disposing;
+    }
+#endif
 }

--- a/tests/Grace.Tests/DependencyInjection/DisposableTests/DisposalCleanupTests.cs
+++ b/tests/Grace.Tests/DependencyInjection/DisposableTests/DisposalCleanupTests.cs
@@ -1,4 +1,5 @@
-﻿using Grace.DependencyInjection;
+﻿using System.Threading.Tasks;
+using Grace.DependencyInjection;
 using Grace.Tests.Classes.Simple;
 using Xunit;
 
@@ -6,6 +7,27 @@ namespace Grace.Tests.DependencyInjection.DisposableTests
 {
     public class DisposalCleanupTests
     {
+#if NET5_0
+        [Fact]
+        public async Task Export_AsyncDisposableCleanup_Called()
+        {
+            var container = new DependencyInjectionContainer();
+
+            var disposedDelegateCalled = false;
+
+            container.Configure(c => c.Export<AsyncDisposableService>().As<IDisposableService>().DisposalCleanupDelegate(d => disposedDelegateCalled = true));
+
+            await using (var scope = container.BeginLifetimeScope())
+            {
+                var instance = scope.Locate<IDisposableService>();
+
+                Assert.NotNull(instance);
+            }
+
+            Assert.True(disposedDelegateCalled);
+        }
+#endif
+
         [Fact]
         public void Export_DisposableCleanup_Called()
         {

--- a/tests/Grace.Tests/DependencyInjection/DisposableTests/DisposalScopeTests.cs
+++ b/tests/Grace.Tests/DependencyInjection/DisposableTests/DisposalScopeTests.cs
@@ -1,4 +1,5 @@
-﻿using Grace.DependencyInjection.Impl;
+﻿using System.Threading.Tasks;
+using Grace.DependencyInjection.Impl;
 using Grace.Tests.Classes.Simple;
 using Xunit;
 
@@ -6,6 +7,112 @@ namespace Grace.Tests.DependencyInjection.DisposableTests
 {
     public class DisposalScopeTests
     {
+
+#if NET5_0
+
+        [Fact]
+        public async Task DisposalScope_DisposeAsyncMixedResourcesTest()
+        {
+            var disposalScope = new DisposalScope();
+            var asyncDisposableService = new AsyncDisposableService();
+            var disposableService = new DisposableService();
+            var disposeEventFired = false;
+            var asyncDisposeEventFired = false;
+
+            disposableService.Disposing += (sender, args) => disposeEventFired = true;
+            asyncDisposableService.Disposing += (sender, args) => asyncDisposeEventFired = true;
+
+            disposalScope.AddAsyncDisposable(asyncDisposableService);
+            disposalScope.AddDisposable(disposableService);
+
+            await disposalScope.DisposeAsync();
+
+            Assert.True(disposeEventFired && asyncDisposeEventFired);
+        }
+
+        [Fact]
+        public void DisposalScope_DisposeMixedResourcesTest()
+        {
+            var disposalScope = new DisposalScope();
+            var asyncDisposableService = new AsyncDisposableService();
+            var disposableService = new DisposableService();
+            var disposeEventFired = false;
+            var asyncDisposeEventFired = false;
+
+            disposableService.Disposing += (sender, args) => disposeEventFired = true;
+            asyncDisposableService.Disposing += (sender, args) => asyncDisposeEventFired = true;
+
+            disposalScope.AddAsyncDisposable(asyncDisposableService);
+            disposalScope.AddDisposable(disposableService);
+
+            disposalScope.Dispose();
+
+            Assert.True(disposeEventFired && !asyncDisposeEventFired);
+        }
+
+        [Fact]
+        public async Task DisposalScope_DisposeAsyncCalledTest()
+        {
+            var disposalScope = new DisposalScope();
+            var disposableService = new AsyncDisposableService();
+            var eventFired = false;
+
+            disposableService.Disposing += (sender, args) => eventFired = true;
+
+            disposalScope.AddAsyncDisposable(disposableService);
+
+            await disposalScope.DisposeAsync();
+
+            Assert.True(eventFired);
+        }
+
+        [Fact]
+        public async Task DoubleAsyncDisposeTest()
+        {
+            var disposalScope = new DisposalScope();
+            var disposableService = new AsyncDisposableService();
+            var eventFired = false;
+
+            disposableService.Disposing += (sender, args) => eventFired = true;
+
+            disposalScope.AddAsyncDisposable(disposableService);
+
+            await disposalScope.DisposeAsync();
+
+            Assert.True(eventFired);
+
+            eventFired = false;
+
+            await disposalScope.DisposeAsync();
+
+            Assert.False(eventFired);
+        }
+
+        [Fact]
+        public async Task CleanUpDelegateAsyncTest()
+        {
+            var disposalScope = new DisposalScope();
+            var disposableService = new AsyncDisposableService();
+            var eventFired = false;
+            var cleanUpCalled = false;
+
+            disposableService.Disposing += (sender, args) => eventFired = true;
+
+            disposalScope.AddAsyncDisposable(disposableService,
+                disposed =>
+                {
+                    Assert.True(ReferenceEquals(disposableService, disposed));
+
+                    cleanUpCalled = true;
+                });
+
+            await disposalScope.DisposeAsync();
+
+            Assert.True(eventFired);
+            Assert.True(cleanUpCalled);
+        }
+#endif
+
         [Fact]
         public void DisposalScope_DisposeCalledTest()
         {

--- a/tests/Grace.Tests/Grace.Tests.csproj
+++ b/tests/Grace.Tests/Grace.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net5.0;net452</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.0</TargetFrameworks>
     <AssemblyName>Grace.Tests</AssemblyName>
     <PackageId>Grace.Tests</PackageId>


### PR DESCRIPTION
According to our discussion in #243, I've made the following changes:

- Added netstandard2.1 target for Grace package and .Net 5.0 for tests.
- IDisposalScope extended with IAsyncDisposable implementation.
- TypeExpressionBuilder now checks for IAsyncDisposable interface along with IDisposable.
- Implemented changes into tests to allow proper testing with added .Net 5.0 target framework. 

I **did not** change the version in appveyor.yml. 
I think we have to build a pre-release first to proceed with changes and integration testing in Grace.DependencyInjection.Extensions.
After successful implementation, we can release a stable version for both packages. 

Also, with the support of netstandard2.1 features, the codebase looks messy. It would be great to have some decommission plans for netstandard1.0, netstandard2.0, and net45 to push the usage of the latest language features.

I am looking forward to your feedback.