### PR TITLE
Consolidate target frameworks

### DIFF
--- a/src/Grace.Dynamic/Grace.Dynamic.csproj
+++ b/src/Grace.Dynamic/Grace.Dynamic.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Description>IL Generation library for Grace dependency injection container</Description>
     <Authors>Ian Johnson</Authors>
-    <TargetFrameworks>netstandard1.1;net45;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Grace.Dynamic</AssemblyName>
     <AssemblyOriginatorKeyFile>..\Grace.snk</AssemblyOriginatorKeyFile>
@@ -17,7 +16,6 @@
     <PackageIconUrl>https://github.com/ipjohnson/Grace/raw/master/img/logo-64.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/ipjohnson/Grace</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -36,17 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="System.Reflection.Emit" Version="4.0.1" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.Factory/Grace.Factory.csproj
+++ b/src/Grace.Factory/Grace.Factory.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Description>IL Generation library for Grace dependency injection container</Description>
     <Authors>Ian Johnson</Authors>
-    <TargetFrameworks>netstandard1.1;net45;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Grace.Factory</AssemblyName>
     <AssemblyOriginatorKeyFile>..\Grace.snk</AssemblyOriginatorKeyFile>
@@ -17,7 +16,6 @@
     <PackageIconUrl>https://github.com/ipjohnson/Grace/raw/master/img/logo-64.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/ipjohnson/Grace</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -36,17 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="System.Reflection.Emit" Version="4.0.1" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace/Grace.csproj
+++ b/src/Grace/Grace.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Grace is a feature rich Dependency Injection Container</Description>
+    <Description>Grace is a feature-rich dependency injection container designed with ease of use and performance in mind.</Description>
     <Authors>Ian Johnson</Authors>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;netstandard2.1;net45;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Grace</AssemblyName>
@@ -18,7 +18,6 @@
     <PackageIconUrl>https://github.com/ipjohnson/Grace/raw/master/img/logo-64.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/ipjohnson/Grace</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -33,18 +32,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup> 
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Grace.Tests/DependencyInjection/Extensions/GraceExtensions.cs
+++ b/tests/Grace.Tests/DependencyInjection/Extensions/GraceExtensions.cs
@@ -20,6 +20,7 @@ namespace Grace.Tests.DependencyInjection.Extensions
         {
             exportLocator.Configure(c =>
             {
+                c.Export<ServiceProviderIsServiceImpl>().As<IServiceProviderIsService>();
                 c.Export<GraceServiceProvider>().As<IServiceProvider>();
                 c.Export<GraceLifetimeScopeServiceScopeFactory>().As<IServiceScopeFactory>();
                 Register(c, descriptors);
@@ -40,9 +41,9 @@ namespace Grace.Tests.DependencyInjection.Extensions
                 }
                 else if (descriptor.ImplementationFactory != null)
                 {
-                    c.ExportInstance((scope, context) => descriptor.ImplementationFactory(new GraceServiceProvider(scope))).
-                        As(descriptor.ServiceType).
-                        ConfigureLifetime(descriptor.Lifetime);
+                    c.ExportFactory<IExportLocatorScope, StaticInjectionContext, object>((scope, _) => descriptor.ImplementationFactory(new GraceServiceProvider(scope)))
+                     .As(descriptor.ServiceType)
+                     .ConfigureLifetime(descriptor.Lifetime);
                 }
                 else
                 {

--- a/tests/Grace.Tests/DependencyInjection/Extensions/InjectionSpecificationTests.cs
+++ b/tests/Grace.Tests/DependencyInjection/Extensions/InjectionSpecificationTests.cs
@@ -17,4 +17,24 @@ namespace Grace.Tests.DependencyInjection.Extensions
             return container.Populate(serviceCollection);
         }
     }
+
+    internal class ServiceProviderIsServiceImpl : IServiceProviderIsService
+    {
+        private readonly IExportLocatorScope _exportLocatorScope;
+
+        public ServiceProviderIsServiceImpl(IExportLocatorScope exportLocatorScope)
+        {
+            _exportLocatorScope = exportLocatorScope;
+        }
+
+        public bool IsService(Type serviceType)
+        {
+            if (serviceType.IsGenericTypeDefinition)
+            {
+                return false;
+            }
+
+            return _exportLocatorScope.CanLocate(serviceType);
+        }
+    }
 }

--- a/tests/Grace.Tests/Grace.Tests.csproj
+++ b/tests/Grace.Tests/Grace.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net6.0;net452</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <AssemblyName>Grace.Tests</AssemblyName>
     <PackageId>Grace.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -20,28 +19,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Castle.Core" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Optional" Version="4.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="SimpleFixture.NSubstitute" Version="3.0.6" />
+    <PackageReference Include="SimpleFixture.xUnit" Version="3.0.6" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="1.1.1" />
-    <PackageReference Include="SimpleFixture.NSubstitute" Version="3.0.6" />
-    <PackageReference Include="SimpleFixture.xUnit" Version="3.0.6" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now that .NET Core 3.1 is no longer supported, both .NET Core and .NET Standard could be considered dead.

We should be more specific and up-to-date with what frameworks Grace targets.

* Target the earliest supported .NET Framework, which until 2027 is going to be  4.6.2. In other words, drop support for .NET Framework 4.5 (which went EOL in 2016).

![image](https://user-images.githubusercontent.com/1554615/208128841-838115cb-2bb2-4673-8f86-d26d05b539f5.png)

* Drop support for .NET Standard and only use .NET from now on. .NET 6 is the latest LTS and is sufficient enough.

![image](https://user-images.githubusercontent.com/1554615/208129188-a50b27f0-64b4-4127-9a6b-e08dc9655aa9.png)

* The included projects were referencing a couple of dependencies that weren't used. I've also updated all packages to their respective latest version.

* 16 unit tests (all from the Microsoft testing suite) are failing (8 per framework; .NET 6 / .NET Framework 4.6.2), you probably know better than me how to solve this. I tried implementing a custom `IServiceProviderIsService` (as was done in 
_Grace.DependencyInjection.Extensions_), which reduced the number of errors but not all of them.

https://github.com/ipjohnson/Grace.DependencyInjection.Extensions/blob/e5af2af562bd6020fd9f88204f8b866b2fad4aa4/src/Grace.DependencyInjection.Extensions/GraceRegistration.cs#L216-L234